### PR TITLE
Using private static variables instead of constants.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ as you can see it's most simple, concise and intuitive usage
 
 And remember - you have to follow the main rule of creating SQL statements: **every variable should go into query via placeholder only**
 
-###Some technical notes and explanations (or, rather, excuses =).
+### Some technical notes and explanations (or, rather, excuses =).
 
 - **Static singleton implementation**
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ as you can see it's most simple, concise and intuitive usage
 
 And remember - you have to follow the main rule of creating SQL statements: **every variable should go into query via placeholder only**
 
-### Some technical notes and explanations (or, rather, excuses =).
+###Some technical notes and explanations (or, rather, excuses =).
 
 - **Static singleton implementation**
 

--- a/bestpdo.php
+++ b/bestpdo.php
@@ -9,14 +9,14 @@
  *
 **/
 
-define('DB_HOST', 'localhost');
-define('DB_NAME', 'test');
-define('DB_USER', 'root');
-define('DB_PASS', '');
-define('DB_CHAR', 'utf8');
-
 class DB
 {
+    private static $host = 'localhost';
+    private static $user = 'root';
+    private static $pass = '';
+    private static $dbname = 'test';
+    private static $charset = 'utf8';
+
     protected static $instance = null;
 
     final private function __construct() {}
@@ -32,8 +32,8 @@ class DB
 				PDO::ATTR_EMULATE_PREPARES   => TRUE,
 				PDO::ATTR_STATEMENT_CLASS    => array('myPDOStatement'),
 			);
-            $dsn = 'mysql:host='.DB_HOST.';dbname='.DB_NAME.';charset='.DB_CHAR;
-            self::$instance = new PDO($dsn, DB_USER, DB_PASS, $opt);
+            $dsn = 'mysql:host='.self::$host.';dbname='.self::$dbname.';charset='.self::$charset;
+            self::$instance = new PDO($dsn, self::$user, self::$pass, $opt);
         }
         return self::$instance;
     }


### PR DESCRIPTION
Instead of using constants with `define()`, `private static` variables should be used because this will prevent constant and or variable naming conflicts outside the `DB` class.